### PR TITLE
Use Trusted Publisher for npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -23,6 +24,4 @@ jobs:
         env:
           NPM_VERSION: ${{ github.ref_name }}
       - run: npm test
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary
- switch npm publish workflow to OIDC trusted publisher
- remove NPM_TOKEN usage and enable provenance

## Testing
- not run (workflow change only)

Closes #47