### PR TITLE
Ensure OIDC npm publish uses clean npmrc

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,5 +23,7 @@ jobs:
         env:
           NPM_VERSION: ${{ github.ref_name }}
       - run: npm test
-      - run: npm config delete //registry.npmjs.org/:_authToken
+      - run: echo "registry=https://registry.npmjs.org/" > "$RUNNER_TEMP/npmrc"
       - run: npm publish --provenance --access public
+        env:
+          NPM_CONFIG_USERCONFIG: ${{ runner.temp }}/npmrc


### PR DESCRIPTION
## Summary
- stop npm publish from inheriting any auth token
- use a clean npmrc when publishing via OIDC

## Testing
- not run (workflow change)

Closes #51