### PR TITLE
Align npm publish workflow with OIDC docs

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,4 @@
-name: Publish npm
+name: Publish Package
 
 on:
   push:
@@ -19,12 +19,11 @@ jobs:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
-        env:
-          PATCHLINE_SKIP_DOWNLOAD: "1"
       - run: node scripts/prepare-npm-version.js
         env:
           NPM_VERSION: ${{ github.ref_name }}
       - run: npm run build --if-present
       - run: npm test
       - run: npm publish --provenance --access public
+
 

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -115,15 +115,18 @@ async function verifyChecksum(checksums, filename, filePath) {
 }
 
 function shouldSkipDownload(env) {
-  if (env.CI === "true" || env.GITHUB_ACTIONS === "true") {
+  if (Object.prototype.hasOwnProperty.call(env, "PATCHLINE_SKIP_DOWNLOAD")) {
+    const normalized = String(env.PATCHLINE_SKIP_DOWNLOAD).toLowerCase();
+    return normalized === "1" || normalized === "true";
+  }
+
+  const ciValue = String(env.CI || "").toLowerCase();
+  if (ciValue === "1" || ciValue === "true") {
     return true;
   }
-  const flag = env.PATCHLINE_SKIP_DOWNLOAD;
-  if (!flag) {
-    return false;
-  }
-  const normalized = flag.toLowerCase();
-  return normalized === "1" || normalized === "true";
+
+  const actionsValue = String(env.GITHUB_ACTIONS || "").toLowerCase();
+  return actionsValue === "1" || actionsValue === "true";
 }
 
 module.exports = {

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -93,10 +93,12 @@ test("verifyChecksum rejects mismatched hash", async () => {
 test("shouldSkipDownload honors env flag", () => {
   assert.equal(installer.shouldSkipDownload({ PATCHLINE_SKIP_DOWNLOAD: "1" }), true);
   assert.equal(installer.shouldSkipDownload({ PATCHLINE_SKIP_DOWNLOAD: "true" }), true);
+  assert.equal(installer.shouldSkipDownload({ PATCHLINE_SKIP_DOWNLOAD: "false" }), false);
   assert.equal(installer.shouldSkipDownload({ PATCHLINE_SKIP_DOWNLOAD: "" }), false);
 });
 
 test("shouldSkipDownload skips in CI", () => {
   assert.equal(installer.shouldSkipDownload({ CI: "true" }), true);
+  assert.equal(installer.shouldSkipDownload({ CI: "1" }), true);
   assert.equal(installer.shouldSkipDownload({ GITHUB_ACTIONS: "true" }), true);
 });


### PR DESCRIPTION
## Summary
- align npm publish workflow with Trusted Publisher docs
- skip downloads automatically in CI so npm ci doesn't fetch binaries
- expand skip-download tests for CI env values

## Testing
- npm test

Closes #53